### PR TITLE
Fixed oplog_manager connection, now authenticates the correct connection.

### DIFF
--- a/mongo-connector/mongo_connector.py
+++ b/mongo-connector/mongo_connector.py
@@ -188,6 +188,8 @@ class Connector(threading.Thread):
         """Discovers the mongo cluster and creates a thread for each primary.
         """
         main_conn = pymongo.Connection(self.address)
+        if self.auth_key is not None:
+            main_conn['admin'].authenticate(self.auth_username, self.auth_key) 
         self.read_oplog_progress()
         conn_type = None
 

--- a/mongo-connector/oplog_manager.py
+++ b/mongo-connector/oplog_manager.py
@@ -88,6 +88,7 @@ class OplogThread(threading.Thread):
 
         if auth_key is not None:
             #Authenticate for the whole system
+            primary_conn['admin'].authenticate(auth_username, auth_key)
             self.main_connection['admin'].authenticate(auth_username, auth_key)
         if self.oplog.find().count() == 0:
             err_msg = 'OplogThread: No oplog for thread:'
@@ -146,8 +147,8 @@ class OplogThread(threading.Thread):
                 pass
 
             if err is True and self.auth_key is not None:
-                self.main_connection['admin'].authenticate(self.auth_username,
-                                                   self.auth_key)
+                primary_conn['admin'].authenticate(self.auth_username, self.auth_key)
+                self.main_connection['admin'].authenticate(self.auth_username, self.auth_key)
                 err = False
 
             if last_ts is not None:


### PR DESCRIPTION
This fix and using a fully qualified mongodb://-url for the -m parrmeter 
( mongodb://usernam:password@host:port/?replicaSet=setName ) along with -a and -p seems to fix our problems from 10gen-labs/mongo-connector/issues/8
