### PR TITLE
Fixed oplog manager reconnect code for then the primary switches node.

### DIFF
--- a/mongo-connector/oplog_manager.py
+++ b/mongo-connector/oplog_manager.py
@@ -110,7 +110,7 @@ class OplogThread(threading.Thread):
                 continue
 
             #The only entry is the last one we processed
-            if util.retry_until_ok(cursor.count) == 1:
+            if cursor is None or util.retry_until_ok(cursor.count) == 1:
                 time.sleep(1)
                 continue
 


### PR DESCRIPTION
If running against a replica set and if the the primary node falls out of the cluster and another secondary node is selected as master, the mongo-connector script fails.
