### PR TITLE
fix typo that breaks code

### DIFF
--- a/mongo-connector/mongo_connector.py
+++ b/mongo-connector/mongo_connector.py
@@ -412,7 +412,7 @@ def main():
     (options, args) = parser.parse_args()
 
     logger = logging.getLogger()
-    loglevel = logging.info
+    loglevel = logging.INFO
     logger.setLevel(loglevel)
     
     if options.enable_syslog:


### PR DESCRIPTION
Hi, this fix is so simple, I hope this doesn't come off as annoying.  The last commit made it not possible to execute mongo_connector.py due to a typo, and I figured a pr was the most direct way to resolve the issue.
