### PR TITLE
Fix to the issue of the mongo doc manager adding the fields ns and _ts t...

### DIFF
--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -59,6 +59,8 @@ class DocManager():
         """Update or insert a document into Mongo
         """
         database, coll = doc['ns'].split('.', 1)
+        del doc['ns']
+        del doc['_ts']
         try:
             self.mongo[database][coll].save(doc)
         except pymongo.errors.OperationFailure:


### PR DESCRIPTION
In the mongo document manager it assumes that a ns field is passed in the doc.  In fact a ns and a _ts field are both passed in the doc to the mongo document manager and then the manager will insert the entire doc into the target mongo collection.  This results in documents having a ns and a _ts field where they did not before.  This fix removes those two added fields from the document before saving them to the target database.
