### PR TITLE
Ability to specify the list of fields to export.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -56,6 +56,10 @@ databases, and also ignoring the "system.indexes" collection in any database.
 as the unique key for the target system.  The default is "_id",
 which can be noted by "-u _id"
 
+`-i` or `--fields` is used to specify the list of fields to export. Use a comma separated list
+of fields to specify multiple fields. The '_id', 'ns' and '_ts' fields are always exported.
+
+
 `-f` is to specify a file which contains the password for authentication.
 This file is used by mongos to authenticate connections to the shards,
 and we'll use it in the oplog threads. The main use of this option is to specify a

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -48,7 +48,7 @@ class Connector(threading.Thread):
     """Checks the cluster for shards to tail.
     """
     def __init__(self, address, oplog_checkpoint, target_url, ns_set,
-                 u_key, auth_key, doc_manager=None, auth_username=None):
+                 u_key, auth_key, fields, doc_manager=None, auth_username=None):
         if doc_manager is not None:
             doc_manager = imp.load_source('DocManager', doc_manager)
         else:
@@ -86,6 +86,9 @@ class Connector(threading.Thread):
 
         #Dict of OplogThread/timestamp pairs to record progress
         self.oplog_progress = LockingDict()
+
+        # List of fields to export
+        self.fields = fields
 
         try:
             if target_url is None:
@@ -238,6 +241,7 @@ class Connector(threading.Thread):
                 self.oplog_progress,
                 self.ns_set, self.auth_key,
                 self.auth_username,
+                self.fields,
                 repl_set=repl_set)
             self.shard_set[0] = oplog
             logging.info('MongoConnector: Starting connection thread %s' %
@@ -290,7 +294,8 @@ class Connector(threading.Thread):
                                                       self.oplog_progress,
                                                       self.ns_set,
                                                       self.auth_key,
-                                                      self.auth_username)
+                                                      self.auth_username,
+                                                      self.fields)
                     self.shard_set[shard_id] = oplog
                     msg = "Starting connection thread"
                     logging.info("MongoConnector: %s %s" % (msg, shard_conn))
@@ -434,6 +439,14 @@ def main():
                       """Used to specify the syslog facility."""
                       """ The default is 'user'""")
 
+    #-i to specify the list of fields to export
+    parser.add_option("-i", "--fields", action="store", type="string",
+                      dest="fields", default=None, help=
+                      """Used to specify the list of fields to export."""
+                      """ Specify a field or fields to include in the export."""
+                      """ Use a comma separated list of fields to specify multiple fields."""
+                      """ The '_id', 'ns' and '_ts' fields are always exported.""")
+
     (options, args) = parser.parse_args()
 
     logger = logging.getLogger()
@@ -463,6 +476,11 @@ def main():
     else:
         ns_set = options.ns_set.split(',')
 
+    if options.fields is None:
+        fields = []
+    else:
+        fields = options.fields.split(',')
+
     key = None
     if options.auth_file is not None:
         try:
@@ -480,7 +498,7 @@ def main():
         sys.exit(1)
 
     connector = Connector(options.main_addr, options.oplog_config, options.url,
-                   ns_set, options.u_key, key, options.doc_manager,
+                   ns_set, options.u_key, key, fields, options.doc_manager,
                    auth_username=options.admin_name)
 
     connector.start()

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -101,7 +101,7 @@ class TestElastic(unittest.TestCase):
             '%s:%s' % (HOSTNAME, PORTS_ONE['MONGOS']),
             CONFIG, 'localhost:9200',
             ['test.test'],
-            '_id', None,
+            '_id', None, None,
             'mongo_connector/doc_managers/elastic_doc_manager.py')
         self.connector.start()
         while len(self.connector.shard_set) == 0:

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -83,7 +83,7 @@ class TestSynchronizer(unittest.TestCase):
         self.connector = Connector("%s:%s" % (HOSTNAME, PORTS_ONE["MONGOS"]),
            CONFIG, '%s:30000' % (HOSTNAME),
            ['test.test'],
-           '_id', None,
+           '_id', None, None,
            'mongo_connector/doc_managers/mongo_doc_manager.py')
         self.connector.start()
         while len(self.connector.shard_set) == 0:

--- a/tests/test_mongo_connector.py
+++ b/tests/test_mongo_connector.py
@@ -74,7 +74,7 @@ class MongoInternalTester(unittest.TestCase):
             self.fail("Shards cannot be added to mongos")
 
         conn = Connector(MAIN_ADDRESS, CONFIG, None, ['test.test'],
-                      '_id', None, None)
+                      '_id', None, None, None)
         conn.start()
 
         while len(conn.shard_set) != 1:
@@ -92,7 +92,7 @@ class MongoInternalTester(unittest.TestCase):
         os.system('touch %s' % (TEMP_CONFIG))
         config_file_path = TEMP_CONFIG
         conn = Connector(MAIN_ADDRESS, config_file_path, None, ['test.test'],
-                      '_id', None, None)
+                      '_id', None, None, None)
 
         #test that None is returned if there is no config file specified.
         self.assertEqual(conn.write_oplog_progress(), None)
@@ -125,7 +125,7 @@ class MongoInternalTester(unittest.TestCase):
         """
 
         conn = Connector(MAIN_ADDRESS, None, None, ['test.test'], '_id',
-                      None, None)
+                      None, None, None)
 
         #testing with no file
         self.assertEqual(conn.read_oplog_progress(), None)

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -91,7 +91,7 @@ class TestSynchronizer(unittest.TestCase):
 
         self.connector = Connector(('%s:%s' % (HOSTNAME, PORTS_ONE['MAIN'])),
             CONFIG, 'http://localhost:8983/solr', ['test.test'], '_id',
-            None, 
+            None, None,
             'mongo_connector/doc_managers/solr_doc_manager.py')
         self.connector.start()
         while len(self.connector.shard_set) == 0:

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -71,7 +71,7 @@ class TestSynchronizer(unittest.TestCase):
                               replicaSet="demo-repl")
             timer = Timer(60, abort_test)
             cls.connector = Connector("%s:%s" % (HOSTNAME, PORTS_ONE["MONGOS"]),
-                CONFIG, None, ['test.test'], '_id', None, None)
+                CONFIG, None, ['test.test'], '_id', None, None, None)
             cls.synchronizer = cls.connector.doc_manager
             timer.start()
             cls.connector.start()


### PR DESCRIPTION
Hi there,

I've plugged a new `--fields` (`-i`) comma-separated option to restrict the list of fields to export.

I've patched the unit tests but since I don't have the full environment to run them all; I'm not 100% sure they're all passing. Any chance you could run them?
