### PR TITLE
github_61

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,6 +72,10 @@ databases, and also ignoring the "system.indexes" collection in any database.
 as the unique key for the target system.  The default is "_id",
 which can be noted by "-u _id"
 
+`-i` or `--fields` is used to specify the list of fields to export. Use a comma separated list
+of fields to specify multiple fields. The '_id', 'ns' and '_ts' fields are always exported.
+
+
 `-f` is to specify a file which contains the password for authentication.
 This file is used by mongos to authenticate connections to the shards,
 and we'll use it in the oplog threads. The main use of this option is to specify a

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -98,10 +98,12 @@ class TestElastic(unittest.TestCase):
         if not self.flag:
             self.fail("Shards cannot be added to mongos")
         self.connector = Connector(
-            '%s:%s' % (HOSTNAME, PORTS_ONE['MONGOS']),
-            CONFIG, 'localhost:9200',
-            ['test.test'],
-            '_id', None,
+            address='%s:%s' % (HOSTNAME, PORTS_ONE['MONGOS']),
+            oplog_checkpoint=CONFIG,
+            target_url='localhost:9200',
+            ns_set=['test.test'],
+            u_key='_id',
+            auth_key=None,
             doc_manager='mongo_connector/doc_managers/elastic_doc_manager.py'
         )
         self.connector.start()

--- a/tests/test_elastic_doc_manager.py
+++ b/tests/test_elastic_doc_manager.py
@@ -148,8 +148,8 @@ class elastic_docManagerTester(unittest.TestCase):
         search2 = [x["_source"] for x in search2]
         self.assertEqual(len(search), len(search2))
         self.assertTrue(len(search) != 0)
-        for i in range(0, len(search)):
-            self.assertTrue(list(search)[i] == list(search2)[i])
+        self.assertTrue(all(x in search for x in search2) and
+                        all(y in search2 for y in search))
 
     def test_search(self):
         """Query ElasticSearch for docs in a timestamp range.

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -84,10 +84,12 @@ class TestSynchronizer(unittest.TestCase):
         if not self.flag:
             self.fail("Shards cannot be added to mongos")
         self.connector = Connector(
-            "%s:%s" % (HOSTNAME, PORTS_ONE["MONGOS"]),
-            CONFIG, '%s:30000' % (HOSTNAME),
-            ['test.test'],
-            '_id', None,
+            address="%s:%s" % (HOSTNAME, PORTS_ONE["MONGOS"]),
+            oplog_checkpoint=CONFIG,
+            target_url='%s:30000' % (HOSTNAME),
+            ns_set=['test.test'],
+            u_key='_id',
+            auth_key=None,
             doc_manager='mongo_connector/doc_managers/mongo_doc_manager.py'
         )
         self.connector.start()

--- a/tests/test_mongo_connector.py
+++ b/tests/test_mongo_connector.py
@@ -74,8 +74,14 @@ class MongoInternalTester(unittest.TestCase):
         if not self.flag:
             self.fail("Shards cannot be added to mongos")
 
-        conn = Connector(MAIN_ADDRESS, CONFIG, None, ['test.test'],
-                      '_id', None, None)
+        conn = Connector(
+            address=MAIN_ADDRESS,
+            oplog_checkpoint=CONFIG,
+            target_url=None,
+            ns_set=['test.test'],
+            u_key='_id',
+            auth_key=None
+        )
         conn.start()
 
         while len(conn.shard_set) != 1:
@@ -92,8 +98,14 @@ class MongoInternalTester(unittest.TestCase):
         """
         os.system('touch %s' % (TEMP_CONFIG))
         config_file_path = TEMP_CONFIG
-        conn = Connector(MAIN_ADDRESS, config_file_path, None, ['test.test'],
-                      '_id', None, None)
+        conn = Connector(
+            address=MAIN_ADDRESS,
+            oplog_checkpoint=config_file_path,
+            target_url=None,
+            ns_set=['test.test'],
+            u_key='_id',
+            auth_key=None
+        )
 
         #test that None is returned if there is no config file specified.
         self.assertEqual(conn.write_oplog_progress(), None)
@@ -125,8 +137,14 @@ class MongoInternalTester(unittest.TestCase):
         """Test read_oplog_progress
         """
 
-        conn = Connector(MAIN_ADDRESS, None, None, ['test.test'], '_id',
-                      None, None)
+        conn = Connector(
+            address=MAIN_ADDRESS,
+            oplog_checkpoint=None,
+            target_url=None,
+            ns_set=['test.test'],
+            u_key='_id',
+            auth_key=None
+        )
 
         #testing with no file
         self.assertEqual(conn.read_oplog_progress(), None)

--- a/tests/test_mongo_doc_manager.py
+++ b/tests/test_mongo_doc_manager.py
@@ -128,8 +128,8 @@ class MongoDocManagerTester(unittest.TestCase):
         search2 = list(self.mongo.find())
         self.assertTrue(len(search) == len(search2))
         self.assertTrue(len(search) != 0)
-        for i in range(0, len(search)):
-            self.assertTrue(search[i] == search2[i])
+        self.assertTrue(all(x in search for x in search2) and
+                        all(y in search2 for y in search))
 
     def test_search(self):
         """Query Mongo for docs in a timestamp range.
@@ -149,8 +149,9 @@ class MongoDocManagerTester(unittest.TestCase):
         search = list(self.MongoDoc.search(5767301236327972865,
                                            5767301236327972866))
         self.assertTrue(len(search) == 2)
-        self.assertTrue(search[0]['name'] == 'John')
-        self.assertTrue(search[1]['name'] == 'John Paul')
+        result_names = [result.get("name") for result in search]
+        self.assertIn('John', result_names)
+        self.assertIn('John Paul', result_names)
 
     def test_search_namespaces(self):
         """Test search within timestamp range with a given namespace set

--- a/tests/test_oplog_manager.py
+++ b/tests/test_oplog_manager.py
@@ -38,6 +38,7 @@ from tests.setup_cluster import (kill_mongo_proc,
                                           start_mongo_proc,
                                           start_cluster,
                                           kill_all)
+from tests.util import wait_for
 from pymongo.errors import OperationFailure
 from mongo_connector.oplog_manager import OplogThread
 from mongo_connector.util import(long_to_bson_ts,
@@ -416,6 +417,33 @@ class TestOplogManager(unittest.TestCase):
         self.assertTrue(results[0]['_ts'] <= bson_ts_to_long(cutoff_ts))
 
         #test_oplog.join()
+
+    def test_filter_fields(self):
+        opman, _, _ = self.get_oplog_thread()
+        docman = opman.doc_manager
+        conn = opman.main_connection
+
+        include_fields = ["a", "b", "c"]
+        exclude_fields = ["d", "e", "f"]
+
+        # Set fields to care about
+        opman.fields = include_fields
+        # Documents have more than just these fields
+        doc = {
+            "a": 1, "b": 2, "c": 3,
+            "d": 4, "e": 5, "f": 6,
+            "_id": 1
+        }
+        db = conn['test']['test']
+        db.insert(doc)
+        wait_for(lambda: db.count() == 1)
+        opman.dump_collection()
+
+        result = docman._search()[0]
+        keys = result.keys()
+        for inc, exc in zip(include_fields, exclude_fields):
+            self.assertIn(inc, keys)
+            self.assertNotIn(exc, keys)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -90,9 +90,13 @@ class TestSynchronizer(unittest.TestCase):
             self.fail(self.err_msg)
 
         self.connector = Connector(
-            ('%s:%s' % (HOSTNAME, PORTS_ONE['MAIN'])),
-            CONFIG, 'http://localhost:8983/solr', ['test.test'], '_id',
-            None, doc_manager='mongo_connector/doc_managers/solr_doc_manager.py'
+            address=('%s:%s' % (HOSTNAME, PORTS_ONE['MAIN'])),
+            oplog_checkpoint=CONFIG,
+            target_url='http://localhost:8983/solr',
+            ns_set=['test.test'],
+            u_key='_id',
+            auth_key=None,
+            doc_manager='mongo_connector/doc_managers/solr_doc_manager.py'
         )
         self.connector.start()
         while len(self.connector.shard_set) == 0:

--- a/tests/test_solr_doc_manager.py
+++ b/tests/test_solr_doc_manager.py
@@ -120,8 +120,8 @@ class SolrDocManagerTester(unittest.TestCase):
         search2 = self.solr.search('*:*')
         self.assertTrue(len(search) == len(search2))
         self.assertTrue(len(search) != 0)
-        for i in range(0, len(search)):
-            self.assertTrue(list(search)[i] == list(search2)[i])
+        self.assertTrue(all(x in search for x in search2) and
+                        all(y in search2 for y in search))
 
     def test_search(self):
         """Query Solr for docs in a timestamp range.
@@ -140,8 +140,10 @@ class SolrDocManagerTester(unittest.TestCase):
         search2 = self.solr.search('John')
         self.assertTrue(len(search) == len(search2))
         self.assertTrue(len(search) != 0)
-        for i in range(0, len(search)):
-            self.assertTrue(list(search)[i] == list(search2)[i])
+
+        result_names = [result.get("name") for result in search]
+        self.assertIn('John', result_names)
+        self.assertIn('John Paul', result_names)
 
     def test_solr_commit(self):
         """Test that documents get properly added to Solr.

--- a/tests/test_synchronizer.py
+++ b/tests/test_synchronizer.py
@@ -70,8 +70,14 @@ class TestSynchronizer(unittest.TestCase):
             cls.conn = Connection('%s:%s' % (HOSTNAME, PORTS_ONE['MONGOS']),
                               replicaSet="demo-repl")
             timer = Timer(60, abort_test)
-            cls.connector = Connector("%s:%s" % (HOSTNAME, PORTS_ONE["MONGOS"]),
-                CONFIG, None, ['test.test'], '_id', None, None)
+            cls.connector = Connector(
+                address="%s:%s" % (HOSTNAME, PORTS_ONE["MONGOS"]),
+                oplog_checkpoint=CONFIG,
+                target_url=None,
+                ns_set=['test.test'],
+                u_key='_id',
+                auth_key=None
+            )
             cls.synchronizer = cls.connector.doc_manager
             timer.start()
             cls.connector.start()


### PR DESCRIPTION
Ability to specify the list of fields to export.
Add `-i` and `--fields` options to specify the list of fields to export.
Use a comma separated list of fields to specify multiple fields.

python compatibility fixups

github_61: added a test for filter_fields in test_oplog_manager
