### PR TITLE
adding description on docs about the problem with pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,8 @@ Installation
 ~~~~~~~~~~~~
 
 The easiest way to install mongo-connector is with
-`pip <https://pypi.python.org/pypi/pip>`__::
+`pip <https://pypi.python.org/pypi/pip>`__ 
+(it does not include the mongo-connector script `#110 <https://github.com/10gen-labs/mongo-connector/issues/110>`__)::
 
   pip install mongo-connector
 
@@ -28,6 +29,7 @@ manually::
 
 You may have to run ``python setup.py install`` with ``sudo``, depending
 on where you're installing mongo-connector and what privileges you have.
+
 
 Using mongo-connector
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Small description about the current problem installing mongo-connector via pip. Would be nice keep this description meanwhile the pip installation is not updated with the latest version.
