### PR TITLE
Forward entry['o'] to the upsert method.

### DIFF
--- a/mongo_connector/doc_manager.py
+++ b/mongo_connector/doc_manager.py
@@ -45,7 +45,7 @@ class DocManager():
         """
         pass
 
-    def upsert(self, doc):
+    def upsert(self, doc, raw_update_operation=None):
         """Adds a document to the doc dict.
         """
 

--- a/mongo_connector/doc_managers/doc_manager_simulator.py
+++ b/mongo_connector/doc_managers/doc_manager_simulator.py
@@ -48,7 +48,7 @@ class DocManager():
         """
         pass
 
-    def upsert(self, doc):
+    def upsert(self, doc, raw_update_operation=None):
         """Adds a document to the doc dict.
         """
 

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -78,7 +78,7 @@ class DocManager():
         self.auto_commit_interval = None
 
     @wrap_exceptions
-    def upsert(self, doc):
+    def upsert(self, doc, raw_update_operation=None):
         """Update or insert a document into Elastic
 
         If you'd like to have different types of document in your database,

--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -73,7 +73,7 @@ class DocManager():
         """
         pass
 
-    def upsert(self, doc):
+    def upsert(self, doc, raw_update_operation=None):
         """Update or insert a document into Mongo
         """
         database, coll = doc['ns'].split('.', 1)

--- a/mongo_connector/doc_managers/sample_doc_manager.py
+++ b/mongo_connector/doc_managers/sample_doc_manager.py
@@ -63,7 +63,7 @@ class DocManager():
         """
         raise exceptions.NotImplementedError
 
-    def upsert(self, doc):
+    def upsert(self, doc, raw_update_operation=None):
         """Update or insert a document into engine.
         The documents has ns and _ts fields.
 
@@ -78,6 +78,11 @@ class DocManager():
         contents if there is considerable delay in trailing the oplog.
         We have only one function for update and insert because incremental
         updates are not supported, so there is no update option.
+
+        The raw_update_operation parameter contains the update itself using
+        a subset of MongoDB’s $ syntax. If you are only interested in fields
+        being written so you can update a cache, then you only need
+        check the contents of $set
         """
         raise exceptions.NotImplementedError
 

--- a/mongo_connector/doc_managers/solr_doc_manager.py
+++ b/mongo_connector/doc_managers/solr_doc_manager.py
@@ -150,7 +150,7 @@ class DocManager():
         """
         pass
 
-    def upsert(self, doc):
+    def upsert(self, doc, raw_update_operation=None):
         """Update or insert a document into Solr
 
         This method should call whatever add/insert/update method exists for

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -189,7 +189,7 @@ class OplogThread(threading.Thread):
                                     doc['ns'] = ns
                                     for dm in self.doc_managers:
                                         upsert_inc += 1
-                                        dm.upsert(doc)
+                                        dm.upsert(doc, entry['o'])
                         except errors.OperationFailed:
                             logging.error(
                                 "Unable to %s doc with id %s" % (


### PR DESCRIPTION
Hi there,

We're currently working on a new manager and having the info of which fields have been updated would be really appreciated. Actually, that's exactly what `entry['o']` defines.

I'm not sure if there was another more elegant way to pass the info; let me know what you think about it!
