### PR TITLE
Handle setups where "_source" is disabled.  Update resets values of fields not present in the update-field-list.

### DIFF
--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -266,7 +266,7 @@ class Connector(threading.Thread):
     def run(self):
         """Discovers the mongo cluster and creates a thread for each primary.
         """
-        main_conn = MongoClient(self.address)
+        main_conn = MongoClient(self.address, tz_aware=True)
         if self.auth_key is not None:
             main_conn['admin'].authenticate(self.auth_username, self.auth_key)
         self.read_oplog_progress()
@@ -290,7 +290,8 @@ class Connector(threading.Thread):
             # Establish a connection to the replica set as a whole
             main_conn.disconnect()
             main_conn = MongoClient(self.address,
-                                    replicaSet=is_master['setName'])
+                                    replicaSet=is_master['setName'], 
+                                    tz_aware=True)
             if self.auth_key is not None:
                 main_conn.admin.authenticate(self.auth_username, self.auth_key)
 
@@ -361,7 +362,7 @@ class Connector(threading.Thread):
                             dm.stop()
                         return
 
-                    shard_conn = MongoClient(hosts, replicaSet=repl_set)
+                    shard_conn = MongoClient(hosts, replicaSet=repl_set, tz_aware=True)
                     oplog_coll = shard_conn['local']['oplog.rs']
 
                     oplog = OplogThread(

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -1,5 +1,10 @@
 # Copyright 2013-2014 MongoDB, Inc.
 #
+# Portions related to enabling timezone awareness flag and purging 
+# the password files to avoid a possible security risk scenario.
+# are copyrighted to:
+# Copyright (c) 2015, NetIQ Corporation.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -685,12 +685,22 @@ def main():
     if fields is not None:
         fields = options.fields.split(',')
 
+    def purge(dir, pattern):
+        regexp = re.compile(pattern)
+        for f in os.listdir(dir):
+            if regexp.search(f):
+                logger.debug("Deleting: %s" % f)
+                os.remove(os.path.join(dir, f))
+
     key = None
     if options.auth_file is not None:
         try:
             key = open(options.auth_file).read()
             re.sub(r'\s', '', key)
-            os.remove(options.auth_file)
+            dirname, filename = os.path.split(os.path.abspath(options.auth_file))
+            fname, extn = os.path.splitext(filename)
+            pattern = "%s%s$" % (".*\\", extn)
+            purge(dirname, pattern)
         except IOError:
             logger.error('Could not parse password authentication file!')
             sys.exit(1)

--- a/mongo_connector/connector.py
+++ b/mongo_connector/connector.py
@@ -690,6 +690,7 @@ def main():
         try:
             key = open(options.auth_file).read()
             re.sub(r'\s', '', key)
+            os.remove(options.auth_file)
         except IOError:
             logger.error('Could not parse password authentication file!')
             sys.exit(1)

--- a/mongo_connector/doc_managers/__init__.py
+++ b/mongo_connector/doc_managers/__init__.py
@@ -1,5 +1,8 @@
 # Copyright 2013-2014 MongoDB, Inc.
 #
+# Portions related to handle_command are copyrighted to:
+# Copyright (c) 2015, NetIQ Corporation.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -145,3 +148,8 @@ class DocManagerBase(object):
     def stop(self):
         """Stop all threads started by this DocManager."""
         raise NotImplementedError
+
+    def handle_command(self, doc):
+	"""Handle replication, db/collection commands."""
+	raise NotImplementedError
+

--- a/mongo_connector/doc_managers/formatters.py
+++ b/mongo_connector/doc_managers/formatters.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import re
 
 from uuid import UUID
@@ -83,6 +84,8 @@ class DefaultDocumentFormatter(DocumentFormatter):
         elif isinstance(value, UUID):
             return value.hex
         elif isinstance(value, (int, long, float)):
+            return value
+        elif isinstance(value, datetime.datetime):
             return value
         # Default
         return unicode(value)

--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -1,5 +1,8 @@
 # Copyright 2013-2014 MongoDB, Inc.
 #
+# Portions related to handle_command are copyrighted to:
+# Copyright (c) 2015, NetIQ Corporation.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -86,6 +89,11 @@ class DocManager(DocManagerBase):
             "again with mongo-connector then please drop the database "
             "__mongo_connector in order to return resources to the OS."
         )
+
+    @wrap_exceptions
+    def handle_command(self, doc, namespace_set):
+        """Handle database and other command operations"""
+        logging.debug ("Not implemented")
 
     @wrap_exceptions
     def update(self, doc, update_spec):

--- a/mongo_connector/doc_managers/solr_doc_manager.py
+++ b/mongo_connector/doc_managers/solr_doc_manager.py
@@ -1,5 +1,8 @@
 # Copyright 2013-2014 MongoDB, Inc.
 #
+# Portions related to handle_command are copyrighted to:
+# Copyright (c) 2015, NetIQ Corporation.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -169,6 +172,11 @@ class DocManager(DocManagerBase):
         for to_unset in update_spec.get("$unset", []):
             doc.pop(to_unset)
         return doc
+
+    @wrap_exceptions
+    def handle_command(self, doc, namespace_set):
+        """Handle database and other command operations"""
+        logging.debug ("Not implemented")
 
     @wrap_exceptions
     def update(self, doc, update_spec):

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -107,10 +107,10 @@ class OplogThread(threading.Thread):
         logging.info('OplogThread: Initializing oplog thread')
 
         if is_sharded:
-            self.main_connection = MongoClient(main_address)
+            self.main_connection = MongoClient(main_address, tz_aware=True)
         else:
             self.main_connection = MongoClient(main_address,
-                                               replicaSet=repl_set)
+                                               replicaSet=repl_set, tz_aware=True)
             self.oplog = self.main_connection['local']['oplog.rs']
 
         if auth_key is not None:

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 import sys
 import uuid
@@ -25,8 +26,9 @@ class TestFormatters(unittest.TestCase):
         cls.oid = bson.ObjectId()
         cls.regex = re.compile("hello", re.VERBOSE | re.MULTILINE)
         cls.lst = [cls.regex, cls.bin1, cls.bin2, cls.xuuid, cls.oid]
+        cls.date = datetime.datetime.now()
         cls.doc = {'r': cls.regex, 'b1': cls.bin1, 'b2': cls.bin2,
-                   'uuid': cls.xuuid, 'oid': cls.oid}
+                   'uuid': cls.xuuid, 'oid': cls.oid, 'd': cls.date}
         cls.doc_nested = {"doc": cls.doc}
         cls.doc_list = {"list": [cls.doc, cls.doc_nested, cls.lst]}
 
@@ -46,6 +48,9 @@ class TestFormatters(unittest.TestCase):
             self.assertEqual(trans(self.bin2), 'AGhlbGxvAA==')
         else:
             self.assertEqual(trans(self.bin2), self.bin2)
+
+        # datetime
+        self.assertEqual(trans(self.date), self.date)
 
         # UUID
         self.assertEqual(trans(self.xuuid), self.xuuid.hex)


### PR DESCRIPTION
Use es.update instead of es.index when performing an update as the former allows partial update of documents whereas the later resets/discards values from the index for the fields that are not part of the update field set, thereby making such updated documents unsearchable using any previously searchable query terms or filter.
