### PR TITLE
Out of bounds access during $set during Elastic Search update parsing

### DIFF
--- a/mongo_connector/doc_managers/__init__.py
+++ b/mongo_connector/doc_managers/__init__.py
@@ -81,7 +81,13 @@ class DocManagerBase(object):
                     if '.' in to_set:
                         path = to_set.split(".")
                         where = _retrieve_path(doc, path[:-1], create=True)
-                        where[_convert_or_raise(where, path[-1])] = value
+                        if isinstance(where, list):
+                            if _convert_or_raise(where, path[-1]) >= len(where):
+                                where.append(value)
+                            else:
+                                where[_convert_or_raise(where, path[-1])] = value
+                        else:
+                            where[_convert_or_raise(where, path[-1])] = value
                     else:
                         doc[to_set] = value
 


### PR DESCRIPTION
Sometimes during a $set operation I get the following error from mongo-connector (the code I was using is 1.2.1 but I updated to the latest 1.3.0 master and got the same issue):

```
  File "/usr/local/lib/python2.7/dist-packages/mongo_connector-1.2.1_-py2.7.egg/mongo_connector/oplog_manager.py", line 225, in run
    docman.update(doc, entry.get('o', {}))
  File "/usr/local/lib/python2.7/dist-packages/mongo_connector-1.2.1_-py2.7.egg/mongo_connector/doc_managers/__init__.py", line 24, in wrapped
    return f(*args, **kwargs)
  File "/home/rlok/mongo-connector/mongo_connector/doc_managers/elastic_doc_manager.py", line 84, in update
    updated = self.apply_update(document['_source'], update_spec)
  File "/home/rlok/mongo-connector/mongo_connector/doc_managers/elastic_doc_manager.py", line 75, in apply_update
    return super(DocManager, self).apply_update(doc, update_spec)
  File "/usr/local/lib/python2.7/dist-packages/mongo_connector-1.2.1_-py2.7.egg/mongo_connector/doc_managers/__init__.py", line 100, in apply_update
    exc_tb)
  File "/usr/local/lib/python2.7/dist-packages/mongo_connector-1.2.1_-py2.7.egg/mongo_connector/doc_managers/__init__.py", line 84, in apply_update
    where[_convert_or_raise(where, path[-1])] = value
```

I am putting in data that is an array that also contains nested arrays/dicts. Specifically, sometimes the following values are evaluated to:

len(where) = x 
_convert_or_raise(where, path[-1]) = x

therefore: where[_convert_or_raise(where, path[-1])] generates an out of bounds error when `where` is a list. I don't know what cases cause this to happen, but this pull request just double checks the bounds of the array are correct if `where` is a list and if it's not within bounds then just appends it to the end of the list.

I am not sure about the $unset portion of the code as I am unfamiliar with how all the code works. I am unsure if this would cause any issues by simply appending the value to the end of the list.
