### PR TITLE
SolrDocManager: fix _id handling

### DIFF
--- a/mongo_connector/doc_managers/solr_doc_manager.py
+++ b/mongo_connector/doc_managers/solr_doc_manager.py
@@ -124,7 +124,7 @@ class DocManager(DocManagerBase):
         # _id may not exist in the doc, if we retrieved it from Solr
         # as part of update.
         if '_id' in doc:
-            doc[self.unique_key] = doc.pop("_id")
+            doc[self.unique_key] = str(doc.pop("_id"))
 
         # SOLR cannot index fields within sub-documents, so flatten documents
         # with the dot-separated path to each value as the respective key


### PR DESCRIPTION
The id field is converted differently on upsert (`doc.pop("_id")`, which is later handled by pysolr) and update (querying for `str(doc['_id'])`). This means that updates fail for some types of ID, such as UUIDs, that end up with a different representation (e.g. `4e61d3c7-23a9-4b29-8411-e23ab3791a6f` vs. `4e61d3c723a94b298411e23ab3791a6f`).

There is a similar occurrence in `_stream_search()` but I'm not sure if it needs to be fixed.
