### PR TITLE
Bug Fix: Remove added $v as part of Mongo 3.6 update

### DIFF
--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -435,6 +435,10 @@ class OplogThread(threading.Thread):
 
         fields = include_fields or exclude_fields
         entry_o = entry['o']
+        # Version 3.6 of mongodb includes a $v, see https://jira.mongodb.org/browse/SERVER-32240
+        if '$v' in entry_o:
+            entry_o.pop('$v')
+
         # 'i' indicates an insert. 'o' field is the doc to be inserted.
         if entry['op'] == 'i':
             entry['o'] = filter_fields(entry_o, fields)


### PR DESCRIPTION
As part of the Mongo 3.6 update the oplog document's `o` document now contains a version `$v` document.  If all fields in the insert or update are removed (by using the include or exclude fields) it is possible that this `$v` will be the only thing left in the entry document.  This has some dire unintended consequences for the target system. 

For instance, this will cause every update synced from the oplog to be overwritten by a `{ '$v': 1}` in your target data. 

  