### PR TITLE
Adding utility to get the latest oplog timestamp from the replica. 

### DIFF
--- a/mongo_connector/get_last_oplog_timestamp.py
+++ b/mongo_connector/get_last_oplog_timestamp.py
@@ -14,17 +14,17 @@ if len(sys.argv) >= 2:
 
 client = pymongo.MongoClient(mongo_url)
 rs_name = client.admin.command('ismaster')['setName']
-print 'Found Replica Set name: {}'.format(str(rs_name))
+print('Found Replica Set name: {}'.format(str(rs_name)))
 
-print 'Now checking for the latest oplog entry...'
+print('Now checking for the latest oplog entry...')
 oplog = client.local.oplog.rs
 last_oplog = oplog.find().sort('$natural', pymongo.DESCENDING).limit(-1).next()
-print 'Found the last oplog ts: {}'.format(str(last_oplog['ts']))
+print('Found the last oplog ts: {}'.format(str(last_oplog['ts'])))
 last_ts = util.bson_ts_to_long(last_oplog['ts'])
 out_str='["{}", {}]'.format(str(rs_name), str(last_ts) ) 
 
-print 'Writing all to file oplog.timestamp.last in the format required for mongo-connector'
+print('Writing all to file oplog.timestamp.last in the format required for mongo-connector')
 f = open('./oplog.timestamp.last', 'w')
 f.write(out_str)
 f.close()
-print 'All done!'
+print('All done!')

--- a/mongo_connector/get_last_oplog_timestamp.py
+++ b/mongo_connector/get_last_oplog_timestamp.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+import pymongo
+import bson
+import time
+import sys
+from mongo_connector import util
+
+mongo_url = 'mongodb://localhost:27017'
+if len(sys.argv) == 1:
+	print "First argument is mongodb connection string, i.e. localhost:27017. Assuming localhost:27017..."
+if len(sys.argv) >= 2:
+	mongo_url = sys.argv[1]	
+
+
+client = pymongo.MongoClient(mongo_url)
+rs_name = client.admin.command('ismaster')['setName']
+print 'Found Replica Set name: {}'.format(str(rs_name))
+
+print 'Now checking for the latest oplog entry...'
+oplog = client.local.oplog.rs
+last_oplog = oplog.find().sort('$natural', pymongo.DESCENDING).limit(-1).next()
+print 'Found the last oplog ts: {}'.format(str(last_oplog['ts']))
+last_ts = util.bson_ts_to_long(last_oplog['ts'])
+out_str='["{}", {}]'.format(str(rs_name), str(last_ts) ) 
+
+print 'Writing all to file oplog.timestamp.last in the format required for mongo-connector'
+f = open('./oplog.timestamp.last', 'w')
+f.write(out_str)
+f.close()
+print 'All done!'


### PR DESCRIPTION
This is simple utility to get the latest oplog timestamp from the replica.
The utility goal is to fix issue https://github.com/mongodb-labs/mongo-connector/issues/815