### PR TITLE
Deprecate Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ env:
   global:
     - MO_ADDRESS=127.0.0.1:20000
 
+matrix:
+  allow_failures:
+  - python: 2.6
+
 jobs:
   fast_finish: true
   include:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 2.7.0
+-------------
+
+- #829: mongo-connector now emits a warning when running under
+  Python 2.
+
 Version 2.6.0
 -------------
 

--- a/mongo_connector/compat.py
+++ b/mongo_connector/compat.py
@@ -3,6 +3,7 @@
 # flake8: noqa
 
 import sys
+import warnings
 
 PY3 = sys.version_info[0] == 3
 
@@ -25,6 +26,12 @@ if PY3:
 
 
 else:
+    warnings.warn(
+        "Python 2 support is deprecated and pending removal. Please "
+        "run mongo-connector on Python 3. See "
+        "https://github.com/yougov/mongo-connector/issues/829 "
+        "for more details or to post concerns."
+    )
     exec(
         """def reraise(exctype, value, trace=None):
     raise exctype, value, trace"""


### PR DESCRIPTION
This step is the first of two in dropping support for Python 2. Now mongo-connector should emit a warning when imported or started on Python 2.