### PR TITLE
Added support for "continueOnError" for GridFS dump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 3.1.2
+-------------
+
+- Added support for "continueOnError" for GridFS dump
+
 Version 3.1.1
 -------------
 

--- a/mongo_connector/constants.py
+++ b/mongo_connector/constants.py
@@ -16,7 +16,7 @@
 import importlib_metadata
 
 
-__version__ = importlib_metadata.version("mongo_connector")
+__version__ = "3.1.2"
 
 
 # Maximum # of documents to process before recording timestamp

--- a/mongo_connector/oplog_manager.py
+++ b/mongo_connector/oplog_manager.py
@@ -679,7 +679,12 @@ class OplogThread(threading.Thread):
                     dest_ns = self.namespace_config.map_namespace(gridfs_ns)
                     for doc in docs_to_dump(from_coll):
                         gridfile = GridFSFile(mongo_coll, doc)
-                        dm.insert_file(gridfile, dest_ns, long_ts)
+                        try:
+                            dm.insert_file(gridfile, dest_ns, long_ts)
+                        except Exception:
+                            LOG.exception("OplogThread: caught exception during GridFS file insert")
+                            if not self.continue_on_error:
+                                raise
             except Exception:
                 # Likely exceptions:
                 # pymongo.errors.OperationFailure,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Operating System :: POSIX
 
 setup(
     name="mongo-connector",
-    use_scm_version=True,
+    version='3.1.2',
     author="MongoDB, Inc.",
     author_email="mongodb-user@googlegroups.com",
     description="Mongo Connector",


### PR DESCRIPTION
Initial dump does not tolerate GridFS file insertion exception even when continueOnError set to true. This commit updates this behavior.