### PR TITLE
Added support for unicode_decode_error_handler BSON codec options

### DIFF
--- a/mongo_connector/service/config.json
+++ b/mongo_connector/service/config.json
@@ -3,6 +3,7 @@
     "__comment__": "To enable them, remove the preceding '__'",
 
     "mainAddress": "localhost:27017",
+    "unicodeDecode": "strict",
     "oplogFile": "/var/log/mongo-connector/oplog.timestamp",
     "noDump": false,
     "batchSize": -1,


### PR DESCRIPTION
We faced the following issue:
`bson.errors.InvalidBSON: 'utf-8' codec can't decode bytes in position 314-315: invalid continuation byte`

This pull request adds support to pymongo's BSON codec option to overwrite the default `unicode_decode_error_handler=strict'

