### PR TITLE
Don't explicitly create a collection

### DIFF
--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -145,11 +145,6 @@ class DocManager(DocManagerBase):
             if a and b:
                 self.mongo.admin.command("renameCollection", a, to=b)
 
-        if doc.get("create"):
-            new_db, coll = self.command_helper.map_collection(db, doc["create"])
-            if new_db:
-                self.mongo[new_db].create_collection(coll)
-
         if doc.get("drop"):
             new_db, coll = self.command_helper.map_collection(db, doc["drop"])
             if new_db:


### PR DESCRIPTION
# Problem
We have various `mongo` servers that we sync with a central server using `mongo-connector` with the `mongo_doc_manager`.
They all sync into the same collection on the central server.
When a new system is initialized, it has nothing in the DB and `mongo-connector` is running.
When the first entry is made into the local DB, there is an oplog entry to `create` the collection. When `mongo-connector` tries to replay that command on the target DB, `pymongo` throws an exception because the collection already exists on the central server.

Note: this problem does not present itself if `mongo-connector` is started (without an existing `oplog.timestamp`) after the first entry in the local collection has already been made.

# Solution
This problem is easily avoided by not trying to explicitly create the collection, effectively ignoring the `create` entry in the oplog.
This does not cause any problems because `mongo` creates collections automatically whenever a document is inserted into a collection that does not yet exist. The only reason to explicitly create a collection is if special options are specified [as per the documentation](https://pymongo.readthedocs.io/en/stable/api/pymongo/database.html#pymongo.database.Database.create_collection):
> Normally collection creation is automatic. This method should only be used to specify options on creation. CollectionInvalid will be raised if the collection already exists.

Since `mongo_doc_manager` does not specify any options in the `create_collection()` call, that call should not be made.